### PR TITLE
Add License text in script

### DIFF
--- a/dns_to_route53_tf
+++ b/dns_to_route53_tf
@@ -1,3 +1,20 @@
+#    DNS zone file to AWS route53 terraform is a script to convert from
+#    standard DNS to AWS Route 53 in a Terraform file
+#    Copyright (C) 2017 Marc Millien
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 #!/usr/bin/env ruby
 
 def usage


### PR DESCRIPTION
To apply the GPL License, we need to add the text on top of the script
See "How to Apply These Terms to Your New Programs" https://www.gnu.org/licenses/gpl.html